### PR TITLE
Support dynamic networks in CloudConfig via optional fields

### DIFF
--- a/bosh/networks_generator.go
+++ b/bosh/networks_generator.go
@@ -10,7 +10,13 @@ type NetworksGenerator struct {
 type Network struct {
 	Name    string          `yaml:"name"`
 	Type    string          `yaml:"type"`
-	Subnets []NetworkSubnet `yaml:"subnets"`
+	Subnets []NetworkSubnet `yaml:"subnets,omitempty"`
+
+	CloudProperties *NetworkCloudProperties `yaml:"cloud_properties,omitempty"`
+}
+
+type NetworkCloudProperties struct {
+	Subnet string `yaml:"subnet"`
 }
 
 type NetworkSubnet struct {
@@ -24,7 +30,7 @@ type NetworkSubnet struct {
 
 type SubnetCloudProperties struct {
 	Subnet         string   `yaml:"subnet"`
-	SecurityGroups []string `yaml:"security_groups"`
+	SecurityGroups []string `yaml:"security_groups,omitempty"`
 }
 
 func NewNetworksGenerator(inputs []SubnetInput, azAssociations map[string]string) NetworksGenerator {

--- a/bosh/networks_generator_test.go
+++ b/bosh/networks_generator_test.go
@@ -1,11 +1,56 @@
 package bosh_test
 
 import (
+	"github.com/cloudfoundry-incubator/candiedyaml"
 	"github.com/pivotal-cf-experimental/bosh-bootloader/bosh"
+
+	. "github.com/pivotal-cf-experimental/gomegamatchers"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
+
+var _ = Describe("optional network fields", func() {
+	Describe("Network", func() {
+		Context("when Subnets or CloudProperties are missing", func() {
+			It("does not appear in the YAML output", func() {
+				subnet := bosh.Network{
+					Name: "some-network",
+					Type: "some-type",
+				}
+				bytes, _ := candiedyaml.Marshal(subnet)
+				Expect(bytes).To(MatchYAML(`{ "name": "some-network", "type": "some-type" }`))
+			})
+		})
+		Context("when CloudProperties are present", func() {
+			It("marshals them", func() {
+				subnet := bosh.Network{
+					Name: "some-network",
+					Type: "dynamic",
+					CloudProperties: &bosh.NetworkCloudProperties{
+						Subnet: "some-subnet",
+					},
+				}
+				bytes, _ := candiedyaml.Marshal(subnet)
+				Expect(bytes).To(MatchYAML(`
+name: some-network
+type: dynamic
+cloud_properties: { "subnet": "some-subnet" }`))
+			})
+		})
+	})
+	Describe("NetworkSubnetCloudProperties", func() {
+		Context("when SecurityGroups are missing", func() {
+			It("does not appear in the YAML output", func() {
+				subnetCloudProps := bosh.SubnetCloudProperties{
+					Subnet: "some-subnet",
+				}
+				bytes, _ := candiedyaml.Marshal(subnetCloudProps)
+				Expect(bytes).To(MatchYAML(`{ "subnet": "some-subnet" }`))
+			})
+		})
+	})
+})
 
 var _ = Describe("NetworksGenerator", func() {
 	Describe("Generate", func() {


### PR DESCRIPTION
- Dynamic networks can have cloud properties on the top-level Network
- Subnets are only required on manual networks
- Security groups are optional on subnets

For reference: http://bosh.io/docs/aws-cpi.html#networks

