### PR TITLE
Update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ brew install go
 ## Installation
 
 ```
-go get github.com/pivotal-cf-experimental/bosh-bootloader/...
+go get github.com/pivotal-cf-experimental/bosh-bootloader/bbl
 ```
 
 ## Usage


### PR DESCRIPTION
Only go get the bbl program itself.

In Go 1.6, `go get` is smart enough to clone submodules in the vendor directory, so this is sufficient to build the program and run the test suites.

And it's better than `/...` since it doesn't add anything else to your go path -- all dependencies are vendored!