### PR TITLE
Sets enable_post_deploy flag in boshinit manifest

### DIFF
--- a/boshinit/manifests/fixtures/manifest.yml
+++ b/boshinit/manifests/fixtures/manifest.yml
@@ -113,6 +113,7 @@ jobs:
         adapter: postgres
       cpi_job: aws_cpi
       max_threads: 10
+      enable_post_deploy: true
       user_management:
         provider: local
         local:

--- a/boshinit/manifests/job_properties.go
+++ b/boshinit/manifests/job_properties.go
@@ -44,14 +44,16 @@ type BlobstoreJobProperties struct {
 }
 
 type DirectorJobProperties struct {
-	Address        string                   `yaml:"address"`
-	Name           string                   `yaml:"name"`
-	CPIJob         string                   `yaml:"cpi_job"`
-	MaxThreads     int                      `yaml:"max_threads"`
-	DB             PostgresProperties       `yaml:"db"`
-	UserManagement UserManagementProperties `yaml:"user_management"`
-	SSL            SSLProperties            `yaml:"ssl"`
+	Address             string                   `yaml:"address"`
+	Name                string                   `yaml:"name"`
+	CPIJob              string                   `yaml:"cpi_job"`
+	MaxThreads          int                      `yaml:"max_threads"`
+	EnablePostDeploy    bool                     `yaml:"enable_post_deploy"`	
+	DB                  PostgresProperties       `yaml:"db"`
+	UserManagement      UserManagementProperties `yaml:"user_management"`
+	SSL                 SSLProperties            `yaml:"ssl"`
 }
+
 
 type HMJobProperties struct {
 	DirectorAccount    Credentials `yaml:"director_account"`

--- a/boshinit/manifests/job_properties_manifest_builder.go
+++ b/boshinit/manifests/job_properties_manifest_builder.go
@@ -101,6 +101,7 @@ func (j JobPropertiesManifestBuilder) Director(manifestProperties ManifestProper
 		Name:       "my-bosh",
 		CPIJob:     "aws_cpi",
 		MaxThreads: 10,
+		EnablePostDeploy: true,
 		DB:         j.Postgres(),
 		UserManagement: UserManagementProperties{
 			Provider: "local",

--- a/boshinit/manifests/job_properties_manifest_builder_test.go
+++ b/boshinit/manifests/job_properties_manifest_builder_test.go
@@ -154,6 +154,7 @@ var _ = Describe("JobPropertiesManifestBuilder", func() {
 				Name:       "my-bosh",
 				CPIJob:     "aws_cpi",
 				MaxThreads: 10,
+				EnablePostDeploy: true,
 				DB: manifests.PostgresProperties{
 					ListenAddress: "127.0.0.1",
 					Host:          "127.0.0.1",


### PR DESCRIPTION
This turns on the Post Deploy Scripts feature - https://bosh.io/docs/post-deploy.html

Signed-off-by: Sameer Vohra <svohra@pivotal.io>