### PR TITLE
Reduces size of NAT instance to t2.medium

### DIFF
--- a/aws/cloudformation/templates/fixtures/cloudformation_with_cf_elb.json
+++ b/aws/cloudformation/templates/fixtures/cloudformation_with_cf_elb.json
@@ -638,7 +638,7 @@
         "ImageId": {
           "Fn::FindInMap": ["AWSNATAMI", {"Ref": "AWS::Region"}, "AMI"]
         },
-        "InstanceType": "m4.large",
+        "InstanceType": "t2.medium",
         "KeyName": {"Ref": "SSHKeyPairName"},
         "SecurityGroupIds": [{"Ref": "NATSecurityGroup"}],
         "SourceDestCheck": false,

--- a/aws/cloudformation/templates/fixtures/cloudformation_with_concourse_elb.json
+++ b/aws/cloudformation/templates/fixtures/cloudformation_with_concourse_elb.json
@@ -574,7 +574,7 @@
         "ImageId": {
           "Fn::FindInMap": ["AWSNATAMI", {"Ref": "AWS::Region"}, "AMI"]
         },
-        "InstanceType": "m4.large",
+        "InstanceType": "t2.medium",
         "KeyName": {"Ref": "SSHKeyPairName"},
         "SecurityGroupIds": [{"Ref": "NATSecurityGroup"}],
         "SourceDestCheck": false,

--- a/aws/cloudformation/templates/fixtures/cloudformation_without_elb.json
+++ b/aws/cloudformation/templates/fixtures/cloudformation_without_elb.json
@@ -373,7 +373,7 @@
                 "ImageId": {
                     "Fn::FindInMap": ["AWSNATAMI", {"Ref": "AWS::Region"}, "AMI"]
                 },
-                "InstanceType": "m4.large",
+                "InstanceType": "t2.medium",
                 "KeyName": {"Ref": "SSHKeyPairName"},
                 "SecurityGroupIds": [{"Ref": "NATSecurityGroup"}],
                 "SourceDestCheck": false,

--- a/aws/cloudformation/templates/nat_template_builder.go
+++ b/aws/cloudformation/templates/nat_template_builder.go
@@ -48,7 +48,7 @@ func (t NATTemplateBuilder) NAT() Template {
 			"NATInstance": Resource{
 				Type: "AWS::EC2::Instance",
 				Properties: Instance{
-					InstanceType:    "m4.large",
+					InstanceType:    "t2.medium",
 					SubnetId:        Ref{"BOSHSubnet"},
 					SourceDestCheck: false,
 					ImageId: map[string]interface{}{

--- a/aws/cloudformation/templates/nat_template_builder_test.go
+++ b/aws/cloudformation/templates/nat_template_builder_test.go
@@ -59,7 +59,7 @@ var _ = Describe("NATTemplateBuilder", func() {
 			Expect(nat.Resources).To(HaveKeyWithValue("NATInstance", templates.Resource{
 				Type: "AWS::EC2::Instance",
 				Properties: templates.Instance{
-					InstanceType:    "m4.large",
+					InstanceType:    "t2.medium",
 					SubnetId:        templates.Ref{"BOSHSubnet"},
 					SourceDestCheck: false,
 					ImageId: map[string]interface{}{

--- a/bbl/fixtures/cloudformation-no-elb.json
+++ b/bbl/fixtures/cloudformation-no-elb.json
@@ -343,7 +343,7 @@
         "ImageId": {
           "Fn::FindInMap": ["AWSNATAMI", {"Ref": "AWS::Region"}, "AMI"]
         },
-        "InstanceType": "m4.large",
+        "InstanceType": "t2.medium",
         "KeyName": {"Ref": "SSHKeyPairName"},
         "SecurityGroupIds": [{"Ref": "NATSecurityGroup"}],
         "SourceDestCheck": false,


### PR DESCRIPTION
We should be able to run a much smaller NAT instance than m4.large. Hopefully with this we can save a couple dollars on the ol' AWS bill.