### PR TITLE
boshinit/manifests: remove unnecessary manifest properties

### DIFF
--- a/boshinit/manifests/cloud_provider_manifest_builder.go
+++ b/boshinit/manifests/cloud_provider_manifest_builder.go
@@ -67,8 +67,6 @@ func (c CloudProviderManifestBuilder) Build(manifestProperties ManifestPropertie
 				Provider: "local",
 				Path:     "/var/vcap/micro_bosh/data/cache",
 			},
-
-			NTP: sharedPropertiesManifestBuilder.NTP(),
 		},
 	}, manifestProperties, nil
 }

--- a/boshinit/manifests/cloud_provider_manifest_builder_test.go
+++ b/boshinit/manifests/cloud_provider_manifest_builder_test.go
@@ -67,8 +67,6 @@ var _ = Describe("CloudProviderManifestBuilder", func() {
 						Provider: "local",
 						Path:     "/var/vcap/micro_bosh/data/cache",
 					},
-
-					NTP: []string{"0.pool.ntp.org", "1.pool.ntp.org"},
 				},
 			}))
 

--- a/boshinit/manifests/fixtures/manifest.yml
+++ b/boshinit/manifests/fixtures/manifest.yml
@@ -68,32 +68,22 @@ jobs:
       password: nats-some-random-string
 
     postgres:
-      listen_address: 127.0.0.1
-      host: 127.0.0.1
       user: postgres-user-some-random-string
       password: postgres-some-random-string
-      database: bosh
-      adapter: postgres
 
     registry:
-      address: 10.0.0.6
       host: 10.0.0.6
+      address: 10.0.0.6
       db:
-        listen_address: 127.0.0.1
-        host: 127.0.0.1
         user: postgres-user-some-random-string
         password: postgres-some-random-string
         database: bosh
-        adapter: postgres
-      http: {user: registry-user-some-random-string, password: registry-some-random-string, port: 25777}
+      http: {user: registry-user-some-random-string, password: registry-some-random-string}
       username: registry-user-some-random-string
       password: registry-some-random-string
-      port: 25777
 
     blobstore:
       address: 10.0.0.6
-      port: 25250
-      provider: dav
       director: {user: blobstore-director-user-some-random-string, password: blobstore-director-some-random-string}
       agent: {user: blobstore-agent-user-some-random-string, password: blobstore-agent-some-random-string}
 
@@ -101,17 +91,12 @@ jobs:
       address: 127.0.0.1
       name: my-bosh
       db:
-        listen_address: 127.0.0.1
-        host: 127.0.0.1
         user: postgres-user-some-random-string
         password: postgres-some-random-string
-        database: bosh
-        adapter: postgres
       cpi_job: aws_cpi
       max_threads: 10
       enable_post_deploy: true
       user_management:
-        provider: local
         local:
           users:
           - {name: bosh-username, password: bosh-password}
@@ -179,8 +164,6 @@ jobs:
 
     agent: {mbus: "nats://nats-user-some-random-string:nats-some-random-string@10.0.0.6:4222"}
 
-    ntp: [0.pool.ntp.org, 1.pool.ntp.org]
-
 cloud_provider:
   template: {name: aws_cpi, release: bosh-aws-cpi}
 
@@ -201,4 +184,3 @@ cloud_provider:
       region: some-region
     agent: {mbus: "https://mbus-user-some-random-string:mbus-some-random-string@0.0.0.0:6868"}
     blobstore: {provider: local, path: /var/vcap/micro_bosh/data/cache}
-    ntp: [0.pool.ntp.org, 1.pool.ntp.org]

--- a/boshinit/manifests/job_properties.go
+++ b/boshinit/manifests/job_properties.go
@@ -9,7 +9,6 @@ type JobProperties struct {
 	HM        HMJobProperties        `yaml:"hm"`
 	AWS       AWSProperties          `yaml:"aws"`
 	Agent     AgentProperties        `yaml:"agent"`
-	NTP       []string               `yaml:"ntp"`
 }
 
 type NATSJobProperties struct {
@@ -19,19 +18,16 @@ type NATSJobProperties struct {
 }
 
 type RegistryJobProperties struct {
-	Address  string             `yaml:"address"`
-	Host     string             `yaml:"host"`
-	Username string             `yaml:"username"`
-	Password string             `yaml:"password"`
-	Port     int                `yaml:"port"`
-	DB       PostgresProperties `yaml:"db"`
-	HTTP     HTTPProperties     `yaml:"http"`
+	Host     string                     `yaml:"host"`
+	Address  string                     `yaml:"address"`
+	Username string                     `yaml:"username"`
+	Password string                     `yaml:"password"`
+	DB       RegistryPostgresProperties `yaml:"db"`
+	HTTP     HTTPProperties             `yaml:"http"`
 }
 
 type BlobstoreJobProperties struct {
 	Address  string      `yaml:"address"`
-	Port     int         `yaml:"port"`
-	Provider string      `yaml:"provider"`
 	Director Credentials `yaml:"director"`
 	Agent    Credentials `yaml:"agent"`
 }
@@ -62,8 +58,7 @@ type UserProperties struct {
 }
 
 type UserManagementProperties struct {
-	Provider string          `yaml:"provider"`
-	Local    LocalProperties `yaml:"local"`
+	Local LocalProperties `yaml:"local"`
 }
 
 type SSLProperties struct {
@@ -74,7 +69,6 @@ type SSLProperties struct {
 type HTTPProperties struct {
 	User     string `yaml:"user"`
 	Password string `yaml:"password"`
-	Port     int    `yaml:"port"`
 }
 
 type Credentials struct {

--- a/boshinit/manifests/job_properties_manifest_builder.go
+++ b/boshinit/manifests/job_properties_manifest_builder.go
@@ -44,36 +44,33 @@ func (j JobPropertiesManifestBuilder) NATS() NATSJobProperties {
 
 func (j JobPropertiesManifestBuilder) Postgres() PostgresProperties {
 	return PostgresProperties{
-		ListenAddress: "127.0.0.1",
-		Host:          "127.0.0.1",
-		User:          j.postgresUsername,
-		Password:      j.postgresPassword,
-		Database:      "bosh",
-		Adapter:       "postgres",
+		User:     j.postgresUsername,
+		Password: j.postgresPassword,
 	}
 }
 
 func (j JobPropertiesManifestBuilder) Registry() RegistryJobProperties {
+	postgres := j.Postgres()
 	return RegistryJobProperties{
-		Address:  "10.0.0.6",
 		Host:     "10.0.0.6",
+		Address:  "10.0.0.6",
 		Username: j.registryUsername,
 		Password: j.registryPassword,
-		Port:     25777,
-		DB:       j.Postgres(),
+		DB: RegistryPostgresProperties{
+			User:     postgres.User,
+			Password: postgres.Password,
+			Database: "bosh",
+		},
 		HTTP: HTTPProperties{
 			User:     j.registryUsername,
 			Password: j.registryPassword,
-			Port:     25777,
 		},
 	}
 }
 
 func (j JobPropertiesManifestBuilder) Blobstore() BlobstoreJobProperties {
 	return BlobstoreJobProperties{
-		Address:  "10.0.0.6",
-		Port:     25250,
-		Provider: "dav",
+		Address: "10.0.0.6",
 		Director: Credentials{
 			User:     j.blobstoreDirectorUsername,
 			Password: j.blobstoreDirectorPassword,
@@ -94,7 +91,6 @@ func (j JobPropertiesManifestBuilder) Director(manifestProperties ManifestProper
 		EnablePostDeploy: true,
 		DB:               j.Postgres(),
 		UserManagement: UserManagementProperties{
-			Provider: "local",
 			Local: LocalProperties{
 				Users: []UserProperties{
 					{

--- a/boshinit/manifests/job_properties_manifest_builder_test.go
+++ b/boshinit/manifests/job_properties_manifest_builder_test.go
@@ -69,12 +69,8 @@ var _ = Describe("JobPropertiesManifestBuilder", func() {
 		It("returns job properties for Postgres", func() {
 			postgres := jobPropertiesManifestBuilder.Postgres()
 			Expect(postgres).To(Equal(manifests.PostgresProperties{
-				ListenAddress: "127.0.0.1",
-				Host:          "127.0.0.1",
-				User:          postgresUsername,
-				Password:      postgresPassword,
-				Database:      "bosh",
-				Adapter:       "postgres",
+				User:     postgresUsername,
+				Password: postgresPassword,
 			}))
 		})
 	})
@@ -87,19 +83,14 @@ var _ = Describe("JobPropertiesManifestBuilder", func() {
 				Host:     "10.0.0.6",
 				Username: registryUsername,
 				Password: registryPassword,
-				Port:     25777,
-				DB: manifests.PostgresProperties{
-					ListenAddress: "127.0.0.1",
-					Host:          "127.0.0.1",
-					User:          postgresUsername,
-					Password:      postgresPassword,
-					Database:      "bosh",
-					Adapter:       "postgres",
+				DB: manifests.RegistryPostgresProperties{
+					User:     postgresUsername,
+					Password: postgresPassword,
+					Database: "bosh",
 				},
 				HTTP: manifests.HTTPProperties{
 					User:     registryUsername,
 					Password: registryPassword,
-					Port:     25777,
 				},
 			}))
 		})
@@ -109,9 +100,7 @@ var _ = Describe("JobPropertiesManifestBuilder", func() {
 		It("returns job properties for Blobstore", func() {
 			blobstore := jobPropertiesManifestBuilder.Blobstore()
 			Expect(blobstore).To(Equal(manifests.BlobstoreJobProperties{
-				Address:  "10.0.0.6",
-				Port:     25250,
-				Provider: "dav",
+				Address: "10.0.0.6",
 				Director: manifests.Credentials{
 					User:     blobstoreDirectorUsername,
 					Password: blobstoreDirectorPassword,
@@ -141,15 +130,10 @@ var _ = Describe("JobPropertiesManifestBuilder", func() {
 				MaxThreads:       10,
 				EnablePostDeploy: true,
 				DB: manifests.PostgresProperties{
-					ListenAddress: "127.0.0.1",
-					Host:          "127.0.0.1",
-					User:          postgresUsername,
-					Password:      postgresPassword,
-					Database:      "bosh",
-					Adapter:       "postgres",
+					User:     postgresUsername,
+					Password: postgresPassword,
 				},
 				UserManagement: manifests.UserManagementProperties{
-					Provider: "local",
 					Local: manifests.LocalProperties{
 						Users: []manifests.UserProperties{
 							{

--- a/boshinit/manifests/jobs_manifest_builder.go
+++ b/boshinit/manifests/jobs_manifest_builder.go
@@ -71,7 +71,6 @@ func (j JobsManifestBuilder) Build(manifestProperties ManifestProperties) ([]Job
 				HM:        jobPropertiesManifestBuilder.HM(),
 				AWS:       sharedPropertiesManifestBuilder.AWS(manifestProperties),
 				Agent:     jobPropertiesManifestBuilder.Agent(),
-				NTP:       sharedPropertiesManifestBuilder.NTP(),
 			},
 		},
 	}, manifestProperties, nil

--- a/boshinit/manifests/jobs_manifest_builder_test.go
+++ b/boshinit/manifests/jobs_manifest_builder_test.go
@@ -74,7 +74,6 @@ var _ = Describe("JobsManifestBuilder", func() {
 			Expect(job.Properties.NATS.User).To(Equal("nats-user-some-random-string"))
 			Expect(job.Properties.Postgres.User).To(Equal("postgres-user-some-random-string"))
 			Expect(job.Properties.Registry.Username).To(Equal("registry-user-some-random-string"))
-			Expect(job.Properties.Blobstore.Provider).To(Equal("dav"))
 			Expect(job.Properties.Director.Name).To(Equal("my-bosh"))
 			Expect(job.Properties.HM.ResurrectorEnabled).To(Equal(true))
 			Expect(job.Properties.AWS.AccessKeyId).To(Equal("some-access-key-id"))
@@ -82,7 +81,6 @@ var _ = Describe("JobsManifestBuilder", func() {
 			Expect(job.Properties.AWS.Region).To(Equal("some-region"))
 			Expect(job.Properties.AWS.DefaultKeyName).To(Equal("some-key-name"))
 			Expect(job.Properties.Agent.MBus).To(Equal("nats://nats-user-some-random-string:nats-some-random-string@10.0.0.6:4222"))
-			Expect(job.Properties.NTP[0]).To(Equal("0.pool.ntp.org"))
 		})
 
 		It("returns manifest properties with new credentials", func() {

--- a/boshinit/manifests/manifest.go
+++ b/boshinit/manifests/manifest.go
@@ -121,7 +121,6 @@ type CloudProviderProperties struct {
 	AWS       AWSProperties       `yaml:"aws"`
 	Agent     AgentProperties     `yaml:"agent"`
 	Blobstore BlobstoreProperties `yaml:"blobstore"`
-	NTP       []string            `yaml:"ntp"`
 }
 
 type BlobstoreProperties struct {
@@ -142,10 +141,12 @@ type AgentProperties struct {
 }
 
 type PostgresProperties struct {
-	ListenAddress string `yaml:"listen_address"`
-	Host          string `yaml:"host"`
-	User          string `yaml:"user"`
-	Password      string `yaml:"password"`
-	Database      string `yaml:"database"`
-	Adapter       string `yaml:"adapter"`
+	User     string `yaml:"user"`
+	Password string `yaml:"password"`
+}
+
+type RegistryPostgresProperties struct {
+	User     string `yaml:"user"`
+	Password string `yaml:"password"`
+	Database string `yaml:"database"`
 }

--- a/boshinit/manifests/shared_properties_manifest_builder.go
+++ b/boshinit/manifests/shared_properties_manifest_builder.go
@@ -16,7 +16,3 @@ func (SharedPropertiesManifestBuilder) AWS(manifestProperties ManifestProperties
 		Region:                manifestProperties.Region,
 	}
 }
-
-func (SharedPropertiesManifestBuilder) NTP() []string {
-	return []string{"0.pool.ntp.org", "1.pool.ntp.org"}
-}

--- a/boshinit/manifests/shared_properties_manifest_builder_test.go
+++ b/boshinit/manifests/shared_properties_manifest_builder_test.go
@@ -33,13 +33,4 @@ var _ = Describe("SharedPropertiesManifestBuilder", func() {
 			}))
 		})
 	})
-
-	Describe("NTP", func() {
-		It("returns job properties for NTP", func() {
-			ntp := sharedPropertiesManifestBuilder.NTP()
-			Expect(ntp).To(ConsistOf(
-				[]string{"0.pool.ntp.org", "1.pool.ntp.org"},
-			))
-		})
-	})
 })


### PR DESCRIPTION
Lots of the property values provided in the manifest are either not real properties in any job, or it's just providing the value that's already the default.

`./scripts/test` passed locally.

Integration tests also passed: https://mega.ci.cf-app.com/builds/238